### PR TITLE
fix: 修复子应用异步路由路径冲突导致的切换报错问题

### DIFF
--- a/packages/plugin-qiankun/src/index.ts
+++ b/packages/plugin-qiankun/src/index.ts
@@ -9,6 +9,7 @@ export default (appName: string, options?: Options): SettingsPlugin => {
             ...config.output,
             library: `${appName}-[name]`,
             libraryTarget: 'umd',
+            jsonpFunction: `webpackJsonp_${appName}`,
             globalObject: 'window',
         };
         return config;


### PR DESCRIPTION
在子应用App1，App2均适用异步路由拆包时（import()导入）：发现两个如果异步路由内的某个文件路径相同（例如都有一个utils/index.js）但导出内容不同，会报错。

排查发现，如果jsonpFunction数组名称冲突，则会导致挂载冲突。可以通过指定不同的jsonpFunction来解决该问题。