### PR TITLE
fix: 修复strict对requireContext生效相反的bug

### DIFF
--- a/packages/config-webpack/src/partials/strict.ts
+++ b/packages/config-webpack/src/partials/strict.ts
@@ -22,9 +22,9 @@ export default (options: StrictOptions = {}, cwd: string): Configuration => {
         module: {
             parser: {
                 javascript: {
-                    requireContext: disableRequireExtension,
-                    requireEnsure: disableRequireExtension,
-                    requireInclude: disableRequireExtension,
+                    requireContext: !disableRequireExtension,
+                    requireEnsure: !disableRequireExtension,
+                    requireInclude: !disableRequireExtension,
                 },
             },
         },


### PR DESCRIPTION
当前，开启strict之后，requireExtension等会生效，关闭反而不会。发现是webpack配置传反了。