### PR TITLE
docs: 修复文档settings中的一处笔误

### DIFF
--- a/site/docs/settings/settings.md
+++ b/site/docs/settings/settings.md
@@ -6,7 +6,7 @@ title: 配置文件
 
 - `exports.featureMatrix`：参考[特性矩阵](feature-matrix)。
 - `exports.build`：参考[构建](build)。
-- `exports.devServer`：参考[调试服务器]](dev-server)。
+- `exports.devServer`：参考[调试服务器](dev-server)。
 - `exports.plugins`：参考[插件](plugins)。
 
 一个经典的`reskript.config.js`类似如下：


### PR DESCRIPTION
RT

![image](https://user-images.githubusercontent.com/36876080/141255132-0b2380f8-761c-477b-b129-d70687d7d728.png)
