### PR TITLE
修复 qiankun 模式样式 bug

### DIFF
--- a/packages/plugin-qiankun/src/htmlEntry.ts
+++ b/packages/plugin-qiankun/src/htmlEntry.ts
@@ -52,9 +52,11 @@ const defaultTemplate = (appName: string, config?: TemplateConfig) => {
             #sidebar-left {
                 width: ${sidebarLeft.size}px;
                 background-color: ${sidebarLeft.backgroundColor};
+                min-height: calc(100vh - ${header.size}px);
             }
             #apps {
                 flex: 1;
+                overflow: hidden;
             }
             #footer {
                 height: ${footer.size}px;


### PR DESCRIPTION
### qiankun 模式样式 bug
1. 侧边栏没初始化高度，侧边栏塌陷
2. 子应用页面内容过宽撑开父容器