### PR TITLE
feat: 添加 react 代码性能优化转换

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,4 +2,4 @@
 . "$(dirname "$0")/_/husky.sh"
 
 node scripts/check-deps.mjs
-lerna run --exclude-dependents --since HEAD lint
+npx lerna run --exclude-dependents --since HEAD lint

--- a/packages/config-babel/package.json
+++ b/packages/config-babel/package.json
@@ -50,6 +50,8 @@
     "@babel/plugin-proposal-throw-expressions": "^7.16.5",
     "@babel/plugin-syntax-dynamic-import": "^7.8.3",
     "@babel/plugin-syntax-import-meta": "^7.10.4",
+    "@babel/plugin-transform-react-constant-elements": "^7.16.7",
+    "@babel/plugin-transform-react-inline-elements": "^7.16.7",
     "@babel/preset-env": "^7.16.5",
     "@babel/preset-react": "^7.16.5",
     "@babel/preset-typescript": "^7.16.5",

--- a/packages/config-babel/src/transform.ts
+++ b/packages/config-babel/src/transform.ts
@@ -1,5 +1,7 @@
 import {PluginItem, TransformOptions} from '@babel/core';
 import pluginLodash from 'babel-plugin-lodash';
+import pluginReactConstantElement from '@babel/plugin-transform-react-constant-elements';
+import pluginReactInlineElement from '@babel/plugin-transform-react-inline-elements';
 import {compact} from '@reskript/core';
 import addReactDisplayName from '@reskript/babel-plugin-add-react-display-name';
 import {shouldEnable} from './utils.js';
@@ -28,6 +30,12 @@ export default (options: BabelConfigOptionsFilled): TransformOptions => {
                 id: ['lodash', 'lodash-decorators'],
             },
         ],
+        // https://babeljs.io/docs/en/babel-plugin-transform-react-constant-elements
+        // https://github.com/facebook/react/issues/3226
+        pluginReactConstantElement,
+        // https://babeljs.io/docs/en/babel-plugin-transform-react-inline-elements
+        // https://github.com/facebook/react/issues/3228
+        pluginReactInlineElement,
     ];
 
     return {

--- a/packages/config-babel/src/types/babel.d.ts
+++ b/packages/config-babel/src/types/babel.d.ts
@@ -96,6 +96,20 @@ declare module '@babel/plugin-syntax-import-meta' {
     export default target;
 }
 
+declare module '@babel/plugin-transform-react-constant-elements' {
+    import {PluginTarget} from '@babel/core';
+
+    const target: PluginTarget;
+    export default target;
+}
+
+declare module '@babel/plugin-transform-react-inline-elements' {
+    import {PluginTarget} from '@babel/core';
+
+    const target: PluginTarget;
+    export default target;
+}
+
 declare module 'babel-plugin-styled-components' {
     import {PluginTarget} from '@babel/core';
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -386,6 +386,8 @@ importers:
       '@babel/plugin-proposal-throw-expressions': ^7.16.5
       '@babel/plugin-syntax-dynamic-import': ^7.8.3
       '@babel/plugin-syntax-import-meta': ^7.10.4
+      '@babel/plugin-transform-react-constant-elements': ^7.16.7
+      '@babel/plugin-transform-react-inline-elements': ^7.16.7
       '@babel/plugin-transform-typescript': ^7.16.7
       '@babel/preset-env': ^7.16.5
       '@babel/preset-react': ^7.16.5
@@ -424,6 +426,8 @@ importers:
       '@babel/plugin-proposal-throw-expressions': 7.16.7_@babel+core@7.17.2
       '@babel/plugin-syntax-dynamic-import': 7.8.3_@babel+core@7.17.2
       '@babel/plugin-syntax-import-meta': 7.10.4_@babel+core@7.17.2
+      '@babel/plugin-transform-react-constant-elements': 7.16.7_@babel+core@7.17.2
+      '@babel/plugin-transform-react-inline-elements': 7.16.7_@babel+core@7.17.2
       '@babel/preset-env': 7.16.11_@babel+core@7.17.2
       '@babel/preset-react': 7.16.7_@babel+core@7.17.2
       '@babel/preset-typescript': 7.16.7_@babel+core@7.17.2
@@ -1296,6 +1300,14 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/helper-explode-assignable-expression': 7.16.7
+      '@babel/types': 7.17.0
+    dev: false
+
+  /@babel/helper-builder-react-jsx/7.16.7:
+    resolution: {integrity: sha512-XKorXOl2868Un8/XK2o4GLlXr8Q08KthWI5W3qyCkh6tCGf5Ncg3HR4oN2UO+sqPoAlcMgz9elFW/FZvAHYotA==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/helper-annotate-as-pure': 7.16.7
       '@babel/types': 7.17.0
     dev: false
 
@@ -2212,6 +2224,16 @@ packages:
       '@babel/helper-plugin-utils': 7.16.7
     dev: false
 
+  /@babel/plugin-transform-react-constant-elements/7.16.7_@babel+core@7.17.2:
+    resolution: {integrity: sha512-lF+cfsyTgwWkcw715J88JhMYJ5GpysYNLhLP1PkvkhTRN7B3e74R/1KsDxFxhRpSn0UUD3IWM4GvdBR2PEbbQQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.17.2
+      '@babel/helper-plugin-utils': 7.16.7
+    dev: false
+
   /@babel/plugin-transform-react-display-name/7.16.7_@babel+core@7.17.2:
     resolution: {integrity: sha512-qgIg8BcZgd0G/Cz916D5+9kqX0c7nPZyXaP8R2tLNN5tkyIZdG5fEwBrxwplzSnjC1jvQmyMNVwUCZPcbGY7Pg==}
     engines: {node: '>=6.9.0'}
@@ -2220,6 +2242,17 @@ packages:
     dependencies:
       '@babel/core': 7.17.2
       '@babel/helper-plugin-utils': 7.16.7
+
+  /@babel/plugin-transform-react-inline-elements/7.16.7_@babel+core@7.17.2:
+    resolution: {integrity: sha512-jFGuZSebHob02zhrXsJhnI8xcemiDfdlJa1KR2LUfVj/4y9G2iwbJNGVsiH8mW6HEQVh5XwzWWbo/YoroDlQRg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.17.2
+      '@babel/helper-builder-react-jsx': 7.16.7
+      '@babel/helper-plugin-utils': 7.16.7
+    dev: false
 
   /@babel/plugin-transform-react-jsx-development/7.16.7_@babel+core@7.17.2:
     resolution: {integrity: sha512-RMvQWvpla+xy6MlBpPlrKZCMRs2AGiHOGHY3xRwl0pEeim348dDyxeH4xBsMPbIMhujeq7ihE702eM2Ew0Wo+A==}


### PR DESCRIPTION
参考如下 issue 引入了两个 babel plugin：

- https://github.com/facebook/react/issues/3226
- https://github.com/facebook/react/issues/3228

用本地项目测了一下，terser 产物的体积会有非常小的增加，不会导致什么实质影响。