### PR TITLE
docs: fix typo

### DIFF
--- a/site/docs/advanced/multiple-entry.md
+++ b/site/docs/advanced/multiple-entry.md
@@ -15,7 +15,7 @@ title: 多应用入口
 ```
 /my-app
     /src
-        /entrise
+        /entries
             index.tsx
             hello.tsx
     reskript.config.ts


### PR DESCRIPTION
fix `entrise` => `entries` in document